### PR TITLE
Added alternative initializer for ActivityItem

### DIFF
--- a/Sources/ActivityView/ActivityItem.swift
+++ b/Sources/ActivityView/ActivityItem.swift
@@ -1,22 +1,20 @@
 import UIKit
 
-/// Represents an activity for presenting an ActivityView (Share sheet) via the `activitySheet` modifier
+	/// Represents an activity for presenting an ActivityView (Share sheet) via the `activitySheet` modifier
 public struct ActivityItem {
-
-    internal var items: [Any]
-    internal var activities: [UIActivity]
-    internal var excludedTypes: [UIActivity.ActivityType]
-
-    /// The
-    /// - Parameters:
-    ///   - items: The items to share via a `UIActivityViewController`
-    ///   - activities: Custom activities you want to include in the sheet
-    public init(items: Any..., activities: [UIActivity] = [], excludedTypes: [UIActivity.ActivityType] = []) {
-        self.items = items
-        self.activities = activities
-        self.excludedTypes = excludedTypes
-    }
-    
+	
+	internal var items: [Any]
+	internal var activities: [UIActivity]
+	internal var excludedTypes: [UIActivity.ActivityType]
+	
+		/// The variadic form of the initializer
+		/// - Parameters:
+		///   - items: The items to share via a `UIActivityViewController`
+		///   - activities: Custom activities you want to include in the sheet
+	public init(items: Any..., activities: [UIActivity] = [], excludedTypes: [UIActivity.ActivityType] = []) {
+		self.init(items: items, activities: activities, excludedTypes: excludedTypes)
+	}
+	
 		/// An alternative initializer using array syntax (not variadic syntax)
 		/// - Parameters:
 		///   - items: The array of items to share via a `UIActivityViewController`
@@ -26,5 +24,5 @@ public struct ActivityItem {
 		self.activities = activities
 		self.excludedTypes = excludedTypes
 	}
-
+	
 }


### PR DESCRIPTION
New initializer accepts array-based syntax for the `items` argument.