### PR TITLE
Allow invokation without variadic arguments

### DIFF
--- a/Sources/ActivityView/ActivityItem.swift
+++ b/Sources/ActivityView/ActivityItem.swift
@@ -7,11 +7,21 @@ public struct ActivityItem {
     internal var activities: [UIActivity]
     internal var excludedTypes: [UIActivity.ActivityType]
 
-    /// The
+    /// Represents an activity for presenting an ActivityView (Share sheet) via the `activitySheet` modifier
     /// - Parameters:
     ///   - items: The items to share via a `UIActivityViewController`
     ///   - activities: Custom activities you want to include in the sheet
+    ///   - excludedTypes: Activity types to exclude from the sheet
     public init(items: Any..., activities: [UIActivity] = [], excludedTypes: [UIActivity.ActivityType] = []) {
+        self.init(itemsArray: items, activities: activities, excludedTypes: excludedTypes)
+    }
+
+    /// Represents an activity for presenting an ActivityView (Share sheet) via the `activitySheet` modifier.
+    /// - Parameters:
+    ///   - itemsArray: The items to share via a `UIActivityViewController`
+    ///   - activities: Custom activities you want to include in the sheet
+    ///   - excludedTypes: Activity types to exclude from the sheet
+    public init(itemsArray items: [Any], activities: [UIActivity] = [], excludedTypes: [UIActivity.ActivityType] = []) {
         self.items = items
         self.activities = activities
         self.excludedTypes = excludedTypes


### PR DESCRIPTION
*Have you read the [Contributing Guidelines](https://github.com/shaps80/.github/blob/master/CONTRIBUTING.md)?*
yes

Issue #3

## Describe your changes

* Added a non-variadic initializer to `ActivityItem`, leaving the existing function signature intact. Deliberately uses a different function signature `itemsArray items: [Any]` so there is no conflict with the existing initializer/the Any type.
* Fixed missing comment(s)
